### PR TITLE
Fixed SortableBehavior::beforeSave() for postges.

### DIFF
--- a/SortableBehavior.php
+++ b/SortableBehavior.php
@@ -205,6 +205,7 @@ class SortableBehavior extends Behavior
             case self::OPERATION_FIRST:
             case self::OPERATION_LAST:
                 $query = $this->getQueryInternal();
+                $query->orderBy(null);
                 $position = $this->operation === self::OPERATION_LAST ? $query->max($this->sortAttribute) : $query->min($this->sortAttribute);
 
                 $isSelf = false;


### PR DESCRIPTION
There is error in Postgres if we try to sort model with `order by` in query.

Example:

``` php
class MyModel {
    public static function find() {
        return (new ActiveQuery)->orderBy('sort');
    }

    public function behaviors()
    {
        return [
            [
                'class' => MaterializedPathBehavior::class,
            ],
        ];
    }
}

(new MyModel)->nakeRoot()->save(); // There is an error in postgresql
```

``` sql
Exception 'yii\db\Exception' with message 'SQLSTATE[42803]: Grouping error: 7 ERROR:  column "my_model.sort" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: ... AND (my_model."level"=$2) ORDER BY "sort"
                                                                                         ^
The SQL being executed was: SELECT MAX(sort) FROM "my_model" WHERE ("is_removed"=0) AND (my_model."level"=-1) ORDER BY "sort"'
```

We don't need a sorting to get max value. So we can clear `order by` part. And this query starts running well in postgres.
