### PR TITLE
Fix quotting column name for postgresql

### DIFF
--- a/SortableBehavior.php
+++ b/SortableBehavior.php
@@ -206,7 +206,7 @@ class SortableBehavior extends Behavior
             case self::OPERATION_LAST:
                 $query = $this->getQueryInternal();
                 $query->orderBy(null);
-                $position = $this->operation === self::OPERATION_LAST ? $query->max($this->sortAttribute) : $query->min($this->sortAttribute);
+                $position = $this->operation === self::OPERATION_LAST ? $query->max("[[$this->sortAttribute]]") : $query->min("[[$this->sortAttribute]]");
 
                 $isSelf = false;
                 if ($position !== null && !$this->owner->getIsNewRecord() && (int)$position === $this->owner->getAttribute($this->sortAttribute)) {


### PR DESCRIPTION
When using extension with postgre the error about wrong syntax can be occured in beforeSave() method of behavior
![image](https://user-images.githubusercontent.com/41924972/148123951-e6908319-3eb6-4856-8475-bccb44cea4bb.png)

For dealing with it we can just add [[ ]] for names of column for quotting ->min() & ->max() yii\db\ActiveQuery methods
SortableBehavior.php:209
![image](https://user-images.githubusercontent.com/41924972/148124081-bbff6874-9b5d-4e20-ba0c-daf6aeeb9cd0.png)

I dont really understood how to run tests so maybe this fix will only work for postgresql, not for mysql, can you, please, check it or give me some more information how to check this by myself

Thank you!